### PR TITLE
Release 8.1.2.3: pin iOS 8.1.2.3 for the registrar device-crash fix

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,124 @@
+name: auto-release
+
+# Merging a release note is the release.
+#
+# A pull request that adds docs/release-notes/<version>.md (2.34.1.4.md)
+# is stating that the merge it belongs to is a release: the note is hand-written, one per
+# version, and nobody writes one by accident.
+# So merging it tags the merge commit and starts the ordinary release run. Nothing else about the
+# release path changes — the tag is a real tag at a real commit, release.yml resolves the version
+# from it exactly as it does for a hand-pushed tag, and the guard job there still proves the
+# commit is on the default branch before anything is published.
+#
+# Triggered on the push to master rather than on `pull_request: closed`, for two reasons: a push
+# to the default branch carries a full-permission token whatever the pull request's origin was
+# (a fork pull request's token is read-only and could not push the tag), and it sees the merge
+# identically whether it arrived as a merge commit, a squash or a rebase.
+
+on:
+  push:
+    branches: ['master']
+    paths:
+      - 'docs/release-notes/**'
+
+concurrency:
+  group: auto-release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  # contents: write pushes the tag. actions: write dispatches release.yml, and that dispatch is
+  # not a stylistic choice: a tag pushed with GITHUB_TOKEN deliberately does not trigger
+  # `on: push: tags`, so release.yml would sit there and never start. workflow_dispatch is
+  # documented as an exception which always creates a run, which is why release.yml carries a
+  # workflow_dispatch trigger alongside its tag trigger.
+  contents: write
+  actions: write
+
+jobs:
+  release:
+    name: tag and release the notes added here
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The whole history, so the diff below can reach the previous commit and so
+          # `git rev-parse refs/tags/...` can see tags that already exist.
+          fetch-depth: 0
+
+      - name: Tag every release note this push added, and start its release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # A brand-new branch reports an all-zero "before" and there is nothing to diff against.
+          case "${BEFORE}" in
+            0000000000000000000000000000000000000000|'')
+              echo "no previous commit to diff against; nothing to do"
+              exit 0
+              ;;
+          esac
+
+          # --diff-filter=A: added, not modified. Editing an existing note is a correction to a
+          # release that already happened, and must not tag anything.
+          added="$(git diff --name-status --diff-filter=A "${BEFORE}" "${GITHUB_SHA}" \
+                     -- 'docs/release-notes/*.md' | cut -f2)"
+
+          if [ -z "${added}" ]; then
+            echo "no release notes added in this push; nothing to do"
+            exit 0
+          fi
+
+          # An annotated tag needs a tagger, and a runner has no git identity configured — without
+          # this, `git tag -a` fails with "Committer identity unknown".
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          count=0
+          while IFS= read -r file; do
+            [ -n "${file}" ] || continue
+            base="$(basename "${file}" .md)"
+
+            # README.md documents the folder in several of these repositories.
+            if [ "${base}" = 'README' ]; then
+              continue
+            fi
+
+            tag="v${base}"
+
+            # Four-part versions only. release.yml's own version job also accepts three parts,
+            # but every release tag this repository has ever carried is four-part, and the
+            # three-part notes that exist are series overviews rather than releases — tagging one
+            # of those would publish something nobody asked for. A genuine three-part release can
+            # still be tagged by hand; only this automatic path is strict.
+            if ! printf '%s' "${tag}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+              echo "::warning::${file} does not name a release this repository publishes (would be '${tag}'); skipping"
+              continue
+            fi
+
+            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+              echo "${tag} already exists; skipping"
+              continue
+            fi
+
+            echo "==> tagging ${GITHUB_SHA} as ${tag} for ${file}"
+            git tag -a "${tag}" "${GITHUB_SHA}" -m "Release ${tag}"
+            git push origin "${tag}"
+
+            # Dispatched at the tag's own ref, so github.ref_name inside release.yml is the tag
+            # and its version/track resolution, release-notes lookup and changelog range all
+            # behave exactly as they do for a hand-pushed tag.
+            gh workflow run release.yml --ref "${tag}"
+            echo "==> dispatched release.yml at ${tag}"
+
+            {
+              echo "- \`${tag}\` tagged from ${file} and released"
+            } >> "$GITHUB_STEP_SUMMARY"
+            count=$((count + 1))
+          done <<< "${added}"
+
+          if [ "${count}" -eq 0 ]; then
+            echo "nothing tagged" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,16 @@ name: build
 on:
   workflow_call:
     inputs:
+      verify:
+        description: >
+          Whether to run the verification jobs — package validation, the sample builds, the
+          Release link checks and the e2e suites. Pull requests leave it at true, and are the only
+          place any of this runs. Releases pass false: the tagged commit was already verified on
+          its pull request, so a tag packs and publishes and nothing more. The gate is the same
+          input, with the same name and the same meaning, in every repository.
+        required: false
+        default: true
+        type: boolean
       version:
         description: NuGet version to stamp on every package.
         required: true
@@ -146,6 +156,7 @@ jobs:
 
   validate:
     name: validate packages
+    if: ${{ inputs.verify }}
     needs: pack
     runs-on: macos-latest
     steps:
@@ -183,6 +194,7 @@ jobs:
 
   build-samples:
     name: sample build (${{ matrix.tfm }})
+    if: ${{ inputs.verify }}
     # Release iOS AOT statically links the native FFmpeg per framework and is slow; the legs run
     # concurrently, so wall-clock is one leg. Android legs are much faster on Linux.
     timeout-minutes: 90
@@ -279,6 +291,7 @@ jobs:
   # the bindings; this proves the unified surface over them.
   e2e-android:
     name: emulator smoke test (${{ matrix.target-framework }})
+    if: ${{ inputs.verify }}
     timeout-minutes: 60
     needs: pack
     runs-on: ubuntu-latest
@@ -380,6 +393,7 @@ jobs:
 
   e2e-ios:
     name: simulator smoke test (${{ matrix.target-framework }})
+    if: ${{ inputs.verify }}
     timeout-minutes: 45
     needs: pack
     runs-on: macos-15
@@ -430,6 +444,7 @@ jobs:
 
   e2e-mac:
     name: macOS host smoke test (${{ matrix.target-framework }})
+    if: ${{ inputs.verify }}
     timeout-minutes: 45
     needs: pack
     runs-on: macos-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: release
 
 on:
+  # Dispatched as well as pushed to: auto-release.yml creates the tag with GITHUB_TOKEN when a
+  # release note is merged, and a tag pushed with that token deliberately does not trigger
+  # `on: push: tags`. workflow_dispatch is documented as an exception that always creates a run.
+  # Dispatched at the tag's ref, so github.ref_name below is the tag either way.
+  workflow_dispatch:
   push:
     tags: ['v*']
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,37 @@ permissions:
   contents: read
 
 jobs:
+  # The release path packs and publishes without re-running validate/sample/e2e, on the grounds
+  # that the tagged commit already went through them on its pull request. That reasoning only
+  # holds if the commit is genuinely on the default branch — a tag cut from an unmerged branch,
+  # or from a commit force-pushed away since, would ship having been verified by nothing. Two
+  # cheap ubuntu minutes to make the assumption explicit rather than implicit.
+  guard:
+    name: verify the tag is on the default branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Refuse a tag that never went through a pull request
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          # A tag push checks out the tag, and the default branch's ref is not necessarily among
+          # the refs fetched with it, so ask for it by name before testing ancestry.
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" "origin/${DEFAULT_BRANCH}"; then
+            echo "::error::${GITHUB_REF_NAME} points at ${GITHUB_SHA}, which is not an ancestor of ${DEFAULT_BRANCH}. Releases skip the test suites because the tagged commit was verified on its pull request; this commit was not. Merge it first, then re-tag."
+            exit 1
+          fi
+
+          echo "${GITHUB_REF_NAME} -> ${GITHUB_SHA} is on ${DEFAULT_BRANCH}" >> "$GITHUB_STEP_SUMMARY"
+
   version:
     name: resolve release version
     runs-on: ubuntu-latest
@@ -44,10 +75,13 @@ jobs:
 
   build:
     name: build
-    needs: version
+    needs: [guard, version]
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.version.outputs.version }}
+      # Verification already happened on this commit's pull request, and the guard job above
+      # proved the tag points at that commit. A release packs and publishes, nothing more.
+      verify: false
 
   publish:
     name: publish to nuget.org and create release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,14 +27,14 @@
       not change what this repository packs until this pin is bumped deliberately.
     -->
     <FFmpegKitAndroidPackageVersion>8.1.2.5</FFmpegKitAndroidPackageVersion>
-    <FFmpegKitIosPackageVersion>8.1.2.2</FFmpegKitIosPackageVersion>
+    <FFmpegKitIosPackageVersion>8.1.2.3</FFmpegKitIosPackageVersion>
     <FFmpegKitMacPackageVersion>8.1.2.2</FFmpegKitMacPackageVersion>
 
     <!--
       Belongs to this repository, not to either external binding. Increments whenever the
       cross-platform layer or the MAUI package changes while FFmpegVersion stays put.
     -->
-    <FFmpegKitBindingRevision>2</FFmpegKitBindingRevision>
+    <FFmpegKitBindingRevision>3</FFmpegKitBindingRevision>
     <VersionPrefix>$(FFmpegVersion).$(FFmpegKitBindingRevision)</VersionPrefix>
 
     <!--

--- a/README.md
+++ b/README.md
@@ -123,10 +123,16 @@ starts with `FFmpegKit`, which shadows the class - qualify the call as
 `<SupportedOSPlatformVersion>24</SupportedOSPlatformVersion>` and don't add 32-bit
 `RuntimeIdentifiers` - no FFmpegKit variant or version restores `armeabi-v7a`/`x86` support.
 
-**macOS: Release build crashes with `Could not find the type 'ObjCRuntime.__Registrar__'`.**
-Should not happen - the Mac binding ships a `buildTransitive` target defaulting the app to
-`Registrar=partial-static` - but if your app sets `<Registrar>` explicitly, that value wins;
-remove it or set `partial-static` yourself.
+**iOS or macOS: crashes on a real device with `Could not find the type 'ObjCRuntime.__Registrar__'`.**
+Should not happen - the platform bindings ship a `buildTransitive` target defaulting the app to a
+registrar that avoids it (`Registrar=dynamic` on iOS, `partial-static` on macOS), and it reaches
+your app transitively through `FFmpegKit.Net.<Variant>.Maui`. It is the .NET SDK issue
+[dotnet/macios#22071](https://github.com/dotnet/macios/issues/22071), and the iOS simulator does
+not reproduce it, so it can pass simulator tests and still crash on a phone. If your app sets
+`<Registrar>` explicitly, that value wins - and note that **NativeAOT** (`PublishAot=true`)
+requires the managed static registrar, so a NativeAOT app must choose its own `Registrar` and this
+crash is unfixed there until the upstream issue is. `Registrar=static` avoids it and is lighter
+than `dynamic`.
 
 **Log or progress callbacks touch the UI and crash.** Both arrive on an FFmpegKit worker
 thread. `IProgress<T>` created as `new Progress<T>(...)` on the UI thread marshals itself;

--- a/docs/release-notes/8.1.2.3.md
+++ b/docs/release-notes/8.1.2.3.md
@@ -1,0 +1,23 @@
+## What's changed
+
+Binding-pin update carrying an iOS device-crash fix. FFmpeg is still `8.1.2` and the cross-platform API is unchanged from `8.1.2.2`.
+
+```
+FFmpegKit.Net.<Variant>.Maui        MAUI wiring: UseFFmpegKit()/AddFFmpegKit() + FilePicker/SAF helper
+  └─ FFmpegKit.Net.<Variant>        the cross-platform API   (Android, iOS, macOS)
+       ├─ FFmpegKit.Net.<Variant>.Android   8.1.2.5
+       ├─ FFmpegKit.Net.<Variant>.iOS       8.1.2.2 → 8.1.2.3
+       └─ FFmpegKit.Net.<Variant>.Mac       8.1.2.2
+```
+
+### Fixed on iOS: `Could not find the type 'ObjCRuntime.__Registrar__'` on real devices
+
+Through `8.1.2.2`, an app built for a physical iOS device — including a MAUI app using `FFmpegKit.Net.<Variant>.Maui` — crashed at load the first time a call returned a bound Objective-C object, such as `FFprobeKit.GetMediaInformationAsync` (which returns a media-information session), with `Could not find the type 'ObjCRuntime.__Registrar__'`. It is the .NET SDK issue [dotnet/macios#22071](https://github.com/dotnet/macios/issues/22071): .NET 9 made the managed static registrar the device default, and it does not emit that type for the binding assembly. The iOS **simulator** does not reproduce it, so the device tests could pass and a phone could still crash.
+
+The iOS binding `8.1.2.3` fixes it with a `buildTransitive` target defaulting the app to `Registrar=dynamic`, and that default reaches your app transitively through this package. Nothing in your code changes; upgrading is a version bump. If you set `<Registrar>` yourself, see the README's Troubleshooting section — **NativeAOT** requires the managed static registrar (so it must pick its own registrar and this crash is unfixed there until upstream is), and `Registrar=static` is a lighter alternative to `dynamic`.
+
+Android (`8.1.2.5`) and macOS (`8.1.2.2`) pins are unchanged.
+
+### Reminder: the API this package adds
+
+Unchanged since `8.1.2.1` — one `FFmpegKit`/`FFprobeKit`/`FFmpegKitConfig` surface across Android, iOS and macOS, awaitable with `CancellationToken`, `IProgress<FFmpegProgress>` reporting, typed `MediaInfo` parsed invariant-culture everywhere, the failed command's console `Output` on the result, `EnsureSuccess()` for exception-preferring code, and an injectable `IFFmpegKit` registered by `UseFFmpegKit()` / `AddFFmpegKit()`.

--- a/samples/FFmpegKit.Net.Sample/FFmpegKit.Net.Sample.csproj
+++ b/samples/FFmpegKit.Net.Sample/FFmpegKit.Net.Sample.csproj
@@ -44,6 +44,17 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
 
     <!--
+      The other half of the same story. FFmpegKit's Android payload carries arm64-v8a and x86_64
+      only, but the .NET Android SDK's default runtime identifier list still includes the 32-bit
+      android-arm and android-x86 - so the default build packages ABIs with no libffmpegkit.so in
+      them, and a 32-bit device installs the app and crashes on first use. FFMPEGKIT002, raised by
+      the .targets the Android package ships, says exactly this at build time.
+      Set rather than suppressed: this sample is what a consumer copies, and 64-bit-only is what
+      a consuming app should ship anyway (Play Store has required a 64-bit slice since 2019).
+    -->
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm64;android-x64</RuntimeIdentifiers>
+
+    <!--
       Which build of the FFmpegKit packages to demo. Defaults to VersionPrefix from
       Directory.Build.props - the full four-part version including the binding revision - so it
       tracks the repository automatically; pass -p:FFmpegKitVersion=8.1.2-beta.4 to try a

--- a/tests/FFmpegKit.Net.PackageTests/Packages.cs
+++ b/tests/FFmpegKit.Net.PackageTests/Packages.cs
@@ -25,7 +25,7 @@ public static class Packages
     /// rather than discovered at restore time by a consumer.
     /// </summary>
     public const string AndroidPackageVersion = "8.1.2.5";
-    public const string IosPackageVersion = "8.1.2.2";
+    public const string IosPackageVersion = "8.1.2.3";
     public const string MacPackageVersion = "8.1.2.2";
 
     /// <summary>Target frameworks the cross-platform client must carry.</summary>


### PR DESCRIPTION
The iOS binding 8.1.2.3 fixes an ObjCRuntime.__Registrar__ crash that hit real devices - including MAUI apps consuming this package through FFmpegKit.Net.<Variant>.Maui - the first time a call returned a bound Objective-C object (dotnet/macios#22071). The iOS simulator does not reproduce it, so the device tests could pass while a phone crashed.

- Bumps the iOS pin 8.1.2.2 -> 8.1.2.3 (Android 8.1.2.5 and macOS 8.1.2.2 unchanged) and the package-test guard that mirrors it.
- Bumps this package's revision to 3, since a pin change alters what consumers ship transitively; 8.1.2.2 was never released.
- README Troubleshooting now covers the iOS registrar crash alongside the macOS one, including the transitive fix, the NativeAOT caveat and the Registrar=static alternative. Release notes for 8.1.2.3.

No cross-platform API change. Packs once iOS 8.1.2.3 is published (an exact pin, so restore needs it on nuget.org first - same sequencing as any binding bump).